### PR TITLE
Game breaks when no gif result

### DIFF
--- a/tele_giphy/game/views.py
+++ b/tele_giphy/game/views.py
@@ -106,7 +106,6 @@ def select_phrase(request, token):
 
 def choose_new_gif(request, token):
     response = gif_random(tag=request.POST['phrase'])
-    print(response.json())
     try:
         gif = response.json()['data']['image_url']
     except TypeError:

--- a/tele_giphy/game/views.py
+++ b/tele_giphy/game/views.py
@@ -5,6 +5,7 @@ import random
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.contrib import messages
 
 # Localfolder
 from .giphy import gif_random
@@ -105,7 +106,13 @@ def select_phrase(request, token):
 
 def choose_new_gif(request, token):
     response = gif_random(tag=request.POST['phrase'])
-    gif = response.json()['data']['image_url']
+    print(response.json())
+    try:
+        gif = response.json()['data']['image_url']
+    except TypeError:
+        messages.add_message(request, messages.ERROR, 'The phrase you entered could not produce a gif, please try something different.')
+        return HttpResponseRedirect(reverse('game:game_lobby', args=(token,)))
+
 
     g = Game.objects.get(token=token)
     try:

--- a/tele_giphy/game/views.py
+++ b/tele_giphy/game/views.py
@@ -109,7 +109,8 @@ def choose_new_gif(request, token):
     try:
         gif = response.json()['data']['image_url']
     except TypeError:
-        messages.add_message(request, messages.ERROR, 'The phrase you entered could not produce a gif, please try something different.')
+        #messages.add_message(request, messages.ERROR, 'The phrase you entered could not produce a gif, please try something different.')
+        messages.error(request, 'The phrase you entered could not produce a gif, please try something different.')
         return HttpResponseRedirect(reverse('game:game_lobby', args=(token,)))
 
 

--- a/tele_giphy/templates/base.html
+++ b/tele_giphy/templates/base.html
@@ -48,6 +48,17 @@
   {% if error_message %}
     <div class="alert alert-danger text-center" role="alert"><strong>{{ error_message }}</strong></div>
   {% endif %}
+  {% if messages %}
+  <div class="alert alert-danger text-center" role="alert">
+<!--   <ul class="messages"> -->
+    {% for message in messages %}
+<!--     <li{% if message.tags %} class="{{ message.tags }}"{% endif %}> -->
+    {{ message }}<br>
+<!--     </li> -->
+    {% endfor %}
+<!--   </ul> -->
+  </div>
+  {% endif %}
 {% endblock %}
 {% block main_content %}{% endblock %}
 </div>


### PR DESCRIPTION
When the giphy API receives a phrase that does not have any corresponding gif, it does not return a dictionary with key 'data' and therefore a TypeError was raised.

Try/Except was used to filter out this error and display a message to users. I'm gonna create a new issue to standardize the error messaging system (see the html file).

fix #53
