### PR TITLE
Disable pass gif button when no gif is selected

### DIFF
--- a/tele_giphy/game/templates/game/hotseat_gameplay.html
+++ b/tele_giphy/game/templates/game/hotseat_gameplay.html
@@ -67,7 +67,11 @@
   <div class = "col-md-4 col-md-offset-4 text-center">
     <form action = "{% url 'game:pass_on' token %}" method = 'post'>
       {% csrf_token %}
-      <button type="submit" class="btn btn-success">Pass GIF!</button>
+      {% if gif == "http://media0.giphy.com/media/YJBNjrvG5Ctmo/giphy.gif" %}
+        <button type="submit" class="btn btn-success" disabled="disabled">Pass GIF!</button>
+      {% else %}
+        <button type="submit" class="btn btn-success">Pass GIF!</button>
+      {% endif %}
     </form>  
   </div>
 </div> 

--- a/tele_giphy/game/views.py
+++ b/tele_giphy/game/views.py
@@ -14,12 +14,15 @@ from .models import Game
 # Create your views here.
 
 def index(request):
-    """ This is the index view."""
+    """ 
+    This is the index view. That is all.
+    """
     return render(request, 'game/index.html')
 
 
 def new_game(request):
-    """ This view creates a new game token when a user clicks on "New Game" button on index.html
+    """ 
+    This view creates a new game token when a user clicks on "New Game" button on index.html
     This is done randomly and then checks in the database to see if that token is already present.
     If so, it'll keep on trying until it finds a unique token.
     """
@@ -36,7 +39,8 @@ def new_game(request):
 
 
 def join_game(request):
-    """ This view allows a different users to join a pre-exisiting game if it exists.
+    """ 
+    This view allows a different users to join a pre-exisiting game if it exists.
     If it exists, it should also check to see if the user is still able to join the game.
     """
     token = request.POST["join_token"]
@@ -49,15 +53,19 @@ def join_game(request):
 
 
 def waiting_lobby(request, token):
+    """
+    This is where players come to wait until the game can start (should not be part of hotseat)
+    """
     return render(request, 'game/wait.html', {"token": token})
 
 
 def start_game(request, token):
-    # current_game = get_object_or_404(Game, token)
+    """
+    The game is initiated through this view, not actually displayed though
+    """
     current_game = Game.objects.get(token=token)
     current_game.game_active = True
     current_game.save()
-
     return HttpResponseRedirect(reverse('game:game_lobby', args=(token,)))
 
 
@@ -92,15 +100,10 @@ def hotseat_gameplay(request, token):
             'received_gif': received_gif
         }
     return render(request, 'game/hotseat_gameplay.html', context)
-    # if g.current_round is 1:
-    #     return render(request, 'game/hotseat_firstplayer.html', context )
-    # else:
-    #     return render(request, 'game/hotseat_gameplay.html', context)
-
 
 # Not sure what this is for..? \/\/\/        
-def select_phrase(request, token):
-    phrase = request.POST['phrase']
+# def select_phrase(request, token):
+#     phrase = request.POST['phrase']
 
 
 def choose_new_gif(request, token):
@@ -118,7 +121,6 @@ def choose_new_gif(request, token):
                                user_text=request.POST['phrase'],
                                giphy_url=gif)
         g.save()
-
     return HttpResponseRedirect(reverse('game:game_lobby', args=(token,)))
 
 
@@ -128,7 +130,6 @@ def pass_on(request, token):
     g.current_round += 1
     print(g.current_round)
     g.save()
-
     return HttpResponseRedirect(reverse('game:game_lobby', args=(token,)))
 
 # def hot(request):


### PR DESCRIPTION
Pass Gif button is now disabled if the user hasn't clicked the Gif me button. This causes an error if the user doesn't follow the order of clicking correctly.

It might also be a good idea to save the default giphy used for the control flow in the project itself, in case the URL breaks in the future for example.

fix #54 
